### PR TITLE
feat(validators): add validators to models

### DIFF
--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const MovieValidator = require('../../../validators/movie');
+
 exports.register = (server, options, next) => {
   server.route([{
     method: 'POST',
@@ -7,6 +9,9 @@ exports.register = (server, options, next) => {
     config: {
       handler: (request, reply) => {
         reply('hello world');
+      },
+      validate: {
+        payload: MovieValidator
       }
     }
   }]);

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,10 @@ server.connection({ port: Config.PORT });
 
 server.register([
   require('hapi-bookshelf-serializer'),
+  {
+    register: require('hapi-format-error'),
+    options: { joiStatusCode: 422 }
+  },
   require('./plugins/features/movies')
 ], (err) => {
   /* istanbul ignore if */

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const Joi = require('joi');
+
+module.exports = Joi.object().keys({
+  title: Joi.string().min(1).max(255).required(),
+  release_year: Joi.number().integer().min(1878).max(9999).optional()
+});

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "bookshelf": "^1.0.1",
     "hapi": "16.6.1",
     "hapi-bookshelf-serializer": "2.1.0",
+    "hapi-format-error": "^2.1.0",
+    "joi": "12",
     "knex": "^0.20.1",
     "pg": "^7.12.1"
   }

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const Joi = require('joi');
+
+const MovieValidator = require('../../lib/validators/movie');
+
+describe('movie validator', () => {
+
+  describe('title', () => {
+
+    it('is required', () => {
+      const payload = {};
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
+    it('is less than 255 characters', () => {
+      const payload = { title: 'a'.repeat(266) };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('release year', () => {
+
+    it('is after 1878', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 1877
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('is limited to 4 digits', () => {
+      const payload = {
+        title: 'foo',
+        release_year: 18777
+      };
+      const result = Joi.validate(payload, MovieValidator);
+
+      expect(result.error.details[0].path[0]).to.eql('release_year');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+  });
+
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,13 @@ hapi-bookshelf-serializer@2.1.0:
     bluebird "^2.9.34"
     boom "^2.8.0"
 
+hapi-format-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hapi-format-error/-/hapi-format-error-2.1.0.tgz#b6af5fb5adc14db82bccdc681bb4cc1de8182771"
+  integrity sha512-iBMkt1g8PfI1aPHC7vWYQOSWIQ9ESW2Mb5Kg6O4RbJiiDg5WsiMMND7+BLuBepdTGQgkRednbqol4RNNsyN5OQ==
+  dependencies:
+    hoek "^4.2.1"
+
 hapi@16.6.1:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/hapi/-/hapi-16.6.1.tgz#b142f71d0a22d8151c9f5fc04a651ada092bc5c7"
@@ -1377,7 +1384,7 @@ hoek@2.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
   integrity sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=
 
-hoek@4.x.x, hoek@^4.2.0:
+hoek@4.x.x, hoek@^4.2.0, hoek@^4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.1.tgz#9634502aa12c445dd5a7c5734b572bb8738aacbb"
   integrity sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==
@@ -1839,7 +1846,7 @@ joi@10.x.x:
     items "2.x.x"
     topo "2.x.x"
 
-joi@12.x.x:
+joi@12, joi@12.x.x:
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
   integrity sha512-z0FNlV4NGgjQN1fdtHYXf5kmgludM65fG/JlXzU6+rwkt9U5UWuXVYnXa2FpK0u6+qBuCmrm5byPNuiiddAHvQ==


### PR DESCRIPTION
### What:
Add validators to the schema

### Details:
Install Joi library to validate javascript objects.
Created movie validator to ensure title property is required and less than 256 chars.
Ensure release_year property is optional, but if provided, is after 1878 and less than 5 digits. 
Update route configuration to validate payload. 
Format errors using hapi-format-error library. 
Configure plugin on server to use status code 422 for Joi errors. 