### PR TITLE
feat(rename_title): add name and make title nullable

### DIFF
--- a/db/migrations/20191111153039_add_name_to_movies.js
+++ b/db/migrations/20191111153039_add_name_to_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (knex) => {
+  await knex.schema.table('movies', (table) => {
+    table.text('name');
+  });
+  await knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+};
+
+exports.down = async (knex) => {
+  await knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  });
+  await knex.raw('ALTER TABLE moves ALTER COLUMN title SET NOT NULL');
+};


### PR DESCRIPTION
### What
Add new migration that adds a 'name' column, and make the 'title' column nullable. 

### Why
Sfmovie database's 'title' column is being changed to 'name'. Step one of this change is to create a new migration that adds the 'name' column to the database.