### PR TITLE
chore(rename_branch): save name in db, and migration to backfill db name column

### DIFF
--- a/db/migrations/20191112111930_backfill_movies_name.js
+++ b/db/migrations/20191112111930_backfill_movies_name.js
@@ -1,0 +1,9 @@
+'use strict';
+
+exports.up = (knex) => {
+  return knex.raw('UPDATE movies SET name = title');
+};
+
+exports.down = (knex, Promise) => {
+  return Promise.resolve();
+};

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -3,7 +3,9 @@
 const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
-  const movie = await new Movie().save(payload);
+  let newPayload = { name: payload.title };
+  newPayload = Object.assign(newPayload, payload);
+  const movie = await new Movie().save(newPayload);
 
   return new Movie({ id: movie.id }).fetch();
 };


### PR DESCRIPTION
### What

Save incoming payload's title under the name column in db, and backfill name column in db using existing title column. 

### Details
Modify payload in controller so that a payload's title will be saved under both title and name column in database.
Add a new migration file that backfills the name column with information under the title column for all existing rows in database. 