### PR TITLE
feat(add_get_routes): add GET endpoints for movies

### DIFF
--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -8,3 +8,11 @@ exports.create = async (payload) => {
 
   return new Movie({ id: movie.id }).fetch();
 };
+
+exports.fetchAll = async () => {
+  return await Movie.fetchAll();
+};
+
+exports.fetch = async (id) => {
+  return await new Movie({ id }).fetch();
+};

--- a/lib/plugins/features/movies/index.js
+++ b/lib/plugins/features/movies/index.js
@@ -15,6 +15,24 @@ exports.register = (server, options, next) => {
         payload: MovieValidator
       }
     }
+  },
+  {
+    method: 'GET',
+    path: '/movies',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.fetchAll());
+      }
+    }
+  },
+  {
+    method: 'GET',
+    path: '/movies/{id}',
+    config: {
+      handler: (request, reply) => {
+        reply(Controller.fetch(request.params.id));
+      }
+    }
   }]);
 
   next();

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -1,17 +1,49 @@
 'use strict';
 
+const Knex = require('../../../../lib/libraries/knex');
+
 const Controller = require('../../../../lib/plugins/features/movies/controller');
 
 describe('movie controller', () => {
 
+  const payload = { name: 'test', release_year: 2000 };
+
+  beforeEach(async () => {
+    await Knex.truncate('movies');
+  });
+
   describe('create', () => {
 
     it('creates a movie', async () => {
-      const payload = { name: 'foo' };
-
       const movie = await Controller.create(payload);
-
       expect(movie.get('name')).to.eql(payload.name);
+    });
+
+  });
+
+  describe('fetch', () => {
+
+    let movie = {};
+    beforeEach(async () => {
+      movie = await Controller.create(payload);
+    });
+
+    it('fetches a movie', async () => {
+      const fetchedMovie = await Controller.fetch(movie.id);
+      expect(fetchedMovie.get('name')).to.eql(payload.name);
+    });
+
+  });
+
+  describe('fetch all', () => {
+
+    beforeEach(async () => {
+      await Controller.create(payload);
+    });
+
+    it('fetches all movies', async () => {
+      const movies = await Controller.fetchAll();
+      expect(movies.length).to.eql(1);
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -20,4 +20,35 @@ describe('movies integration', () => {
 
   });
 
+  describe('fetch', () => {
+
+    it('fetches a movie', () => {
+      return Movies.inject({
+        url: '/movies/1',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result.id).to.eql(1);
+      });
+
+    });
+
+  });
+
+  describe('fetchAll', () => {
+
+    it('fetches all movies', () => {
+      return Movies.inject({
+        url: '/movies',
+        method: 'GET'
+      })
+      .then((response) => {
+        expect(response.statusCode).to.eql(200);
+        expect(response.result).to.not.be.empty;
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
### What
Add two GET endpoints to movies. GET /movies will return a list of all movies, while GET /movies/:id will return the movie that matches the id provided. 

### Details
Added two new endpoints to the movies controller and routes. When calling GET /movies, the app will return a list of all movies. If an /:id param is supplied, the app will try to match that specific entry in the database and return it instead. 
Unit Testing: Tested all three functions in the controller (create, fetch, fetchAll) by creating a dummy payload and calling the three functions with the dummy payload as the parameter. 
Integration Testing: Used the injection method provided by Hapi.js to check that all endpoints return status code 200 when valid params are passed. 